### PR TITLE
Clean up PKGBUILD a bit

### DIFF
--- a/.github/workflows/makepkg aseprite.yml
+++ b/.github/workflows/makepkg aseprite.yml
@@ -2,7 +2,7 @@ name: Makepkg CI - aseprite
 
 env:
   GPG_TTY: $(tty)
-  NULL: ""
+  NULL: ${{ null }}
 
 on:
   push:

--- a/.github/workflows/makepkg aseprite.yml
+++ b/.github/workflows/makepkg aseprite.yml
@@ -2,7 +2,6 @@ name: Makepkg CI - aseprite
 
 env:
   GPG_TTY: $(tty)
-  NULL: ${{ null }}
 
 on:
   push:
@@ -20,7 +19,7 @@ on:
 
 jobs:
   pkgbuild:
-    if: ${{ secrets.GPG_PRIVATE_KEY }} != ${NULL}
+    if: secrets.GPG_PRIVATE_KEY != null
     runs-on: ubuntu-latest
     container: archlinux/archlinux:base-devel
     steps:
@@ -54,7 +53,7 @@ jobs:
             aseprite/*debug*.zst
             aseprite/*debug*.zst.sig
   prbuild:
-    if: ${{ secrets.GPG_PRIVATE_KEY }} == ${NULL}
+    if: secrets.GPG_PRIVATE_KEY == null
     runs-on: ubuntu-latest
     container: archlinux/archlinux:base-devel
     steps:

--- a/.github/workflows/makepkg aseprite.yml
+++ b/.github/workflows/makepkg aseprite.yml
@@ -2,6 +2,7 @@ name: Makepkg CI - aseprite
 
 env:
   GPG_TTY: $(tty)
+  NULL: ""
 
 on:
   push:
@@ -19,6 +20,7 @@ on:
 
 jobs:
   pkgbuild:
+    if: ${{ secrets.GPG_PRIVATE_KEY }} != ${NULL}
     runs-on: ubuntu-latest
     container: archlinux/archlinux:base-devel
     steps:
@@ -35,6 +37,38 @@ jobs:
         sudo -u builder echo -n "${{ secrets.GPG_PRIVATE_KEY }}" | sudo -u builder base64 --decode | sudo -u builder gpg --import --batch --no-tty
         sudo -u builder gpg --locate-keys torvalds@kernel.org gregkh@kernel.org
         sudo -u builder makepkg -s --sign --noconfirm --config=../makepkg.conf
+    - name: Upload Packages
+      uses: actions/upload-artifact@v2
+      with:
+          name: packages
+          path: |
+            aseprite/*.zst
+            aseprite/*.zst.sig
+            !aseprite/*debug*.zst
+            !aseprite/*debug*.zst.sig
+    #        ${{ steps.makepkg.outputs.pkgfile0 }}.sig
+    - uses: actions/upload-artifact@v2
+      with:
+          name: debug_packages
+          path: |
+            aseprite/*debug*.zst
+            aseprite/*debug*.zst.sig
+  prbuild:
+    if: ${{ secrets.GPG_PRIVATE_KEY }} == ${NULL}
+    runs-on: ubuntu-latest
+    container: archlinux/archlinux:base-devel
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Makepkg
+      run: |
+        pacman -Syu --noconfirm
+        useradd builder -m
+        echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+        chmod -R a+rw .
+        BASEDIR="$PWD"
+        cd aseprite
+        sudo -u builder makepkg -s --noconfirm --config=../makepkg.conf
     - name: Upload Packages
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/makepkg aseprite.yml
+++ b/.github/workflows/makepkg aseprite.yml
@@ -2,6 +2,7 @@ name: Makepkg CI - aseprite
 
 env:
   GPG_TTY: $(tty)
+  PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
 
 on:
   push:
@@ -19,7 +20,7 @@ on:
 
 jobs:
   pkgbuild:
-    if: secrets.GPG_PRIVATE_KEY != null
+    if: PRIVATE_KEY != null
     runs-on: ubuntu-latest
     container: archlinux/archlinux:base-devel
     steps:
@@ -33,7 +34,7 @@ jobs:
         chmod -R a+rw .
         BASEDIR="$PWD"
         cd aseprite
-        sudo -u builder echo -n "${{ secrets.GPG_PRIVATE_KEY }}" | sudo -u builder base64 --decode | sudo -u builder gpg --import --batch --no-tty
+        sudo -u builder echo -n "${PRIVATE_KEY}" | sudo -u builder base64 --decode | sudo -u builder gpg --import --batch --no-tty
         sudo -u builder gpg --locate-keys torvalds@kernel.org gregkh@kernel.org
         sudo -u builder makepkg -s --sign --noconfirm --config=../makepkg.conf
     - name: Upload Packages
@@ -53,7 +54,7 @@ jobs:
             aseprite/*debug*.zst
             aseprite/*debug*.zst.sig
   prbuild:
-    if: secrets.GPG_PRIVATE_KEY == null
+    if: PRIVATE_KEY == null
     runs-on: ubuntu-latest
     container: archlinux/archlinux:base-devel
     steps:

--- a/.github/workflows/makepkg aseprite.yml
+++ b/.github/workflows/makepkg aseprite.yml
@@ -2,7 +2,6 @@ name: Makepkg CI - aseprite
 
 env:
   GPG_TTY: $(tty)
-  PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
 
 on:
   push:
@@ -20,7 +19,7 @@ on:
 
 jobs:
   pkgbuild:
-    if: PRIVATE_KEY != null
+    if: GITHUB_EVENT_NAME != pull_request
     runs-on: ubuntu-latest
     container: archlinux/archlinux:base-devel
     steps:
@@ -34,7 +33,7 @@ jobs:
         chmod -R a+rw .
         BASEDIR="$PWD"
         cd aseprite
-        sudo -u builder echo -n "${PRIVATE_KEY}" | sudo -u builder base64 --decode | sudo -u builder gpg --import --batch --no-tty
+        sudo -u builder echo -n "${{ secrets.GPG_PRIVATE_KEY }}" | sudo -u builder base64 --decode | sudo -u builder gpg --import --batch --no-tty
         sudo -u builder gpg --locate-keys torvalds@kernel.org gregkh@kernel.org
         sudo -u builder makepkg -s --sign --noconfirm --config=../makepkg.conf
     - name: Upload Packages
@@ -54,7 +53,7 @@ jobs:
             aseprite/*debug*.zst
             aseprite/*debug*.zst.sig
   prbuild:
-    if: PRIVATE_KEY == null
+    if: GITHUB_EVENT_NAME == pull_request
     runs-on: ubuntu-latest
     container: archlinux/archlinux:base-devel
     steps:

--- a/.github/workflows/makepkg aseprite.yml
+++ b/.github/workflows/makepkg aseprite.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   pkgbuild:
-    if: github.event.name != pull_request
+    if: github.event.name != 'pull_request'
     runs-on: ubuntu-latest
     container: archlinux/archlinux:base-devel
     steps:
@@ -53,7 +53,7 @@ jobs:
             aseprite/*debug*.zst
             aseprite/*debug*.zst.sig
   prbuild:
-    if: github.event.name == pull_request
+    if: github.event.name == 'pull_request'
     runs-on: ubuntu-latest
     container: archlinux/archlinux:base-devel
     steps:

--- a/.github/workflows/makepkg aseprite.yml
+++ b/.github/workflows/makepkg aseprite.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   pkgbuild:
-    if: GITHUB_EVENT_NAME != pull_request
+    if: github.event.name != pull_request
     runs-on: ubuntu-latest
     container: archlinux/archlinux:base-devel
     steps:
@@ -53,7 +53,7 @@ jobs:
             aseprite/*debug*.zst
             aseprite/*debug*.zst.sig
   prbuild:
-    if: GITHUB_EVENT_NAME == pull_request
+    if: github.event.name == pull_request
     runs-on: ubuntu-latest
     container: archlinux/archlinux:base-devel
     steps:

--- a/.github/workflows/makepkg aseprite.yml
+++ b/.github/workflows/makepkg aseprite.yml
@@ -69,6 +69,7 @@ jobs:
         cd aseprite
         sudo -u builder makepkg -s --noconfirm --config=../makepkg.conf
     - name: Upload Packages
+      if: github.event.name != 'pull_request'
       uses: actions/upload-artifact@v2
       with:
           name: packages
@@ -79,6 +80,7 @@ jobs:
             !aseprite/*debug*.zst.sig
     #        ${{ steps.makepkg.outputs.pkgfile0 }}.sig
     - uses: actions/upload-artifact@v2
+      if: github.event.name != 'pull_request'
       with:
           name: debug_packages
           path: |


### PR DESCRIPTION
Hi! It's been a while. The recent comment on Aseprite breaking after the `{fmt}` 9.x update made me look into the PKGBUILD again, since it prints a warning during the build. This led to the following:

- Remove unused Skia config flags [and add a lengthy comment about *why* the flags are there]
- Disable two unnecessary Skia features [note: I did some light testing and it seemed fine, but I'm far from 100% coverage]
- Remove a duplicate LAF config flag
- Correct use of wrong variable in package()

Additionally, patches are currently applied with offsets, and one even with fuzz. Should we freshen those, or is is not worth the trouble?